### PR TITLE
gauss/zipf: remove hashing to avoid uniform distribution

### DIFF
--- a/init.c
+++ b/init.c
@@ -977,16 +977,12 @@ static void init_rand_file_service(struct thread_data *td)
 	unsigned long nranges = td->o.nr_files << FIO_FSERVICE_SHIFT;
 	const unsigned int seed = td->rand_seeds[FIO_RAND_FILE_OFF];
 
-	if (td->o.file_service_type == FIO_FSERVICE_ZIPF) {
+	if (td->o.file_service_type == FIO_FSERVICE_ZIPF)
 		zipf_init(&td->next_file_zipf, nranges, td->zipf_theta, seed);
-		zipf_disable_hash(&td->next_file_zipf);
-	} else if (td->o.file_service_type == FIO_FSERVICE_PARETO) {
+	else if (td->o.file_service_type == FIO_FSERVICE_PARETO)
 		pareto_init(&td->next_file_zipf, nranges, td->pareto_h, seed);
-		zipf_disable_hash(&td->next_file_zipf);
-	} else if (td->o.file_service_type == FIO_FSERVICE_GAUSS) {
+	else if (td->o.file_service_type == FIO_FSERVICE_GAUSS)
 		gauss_init(&td->next_file_gauss, nranges, td->gauss_dev, seed);
-		gauss_disable_hash(&td->next_file_gauss);
-	}
 }
 
 void td_fill_verify_state_seed(struct thread_data *td)

--- a/lib/gauss.c
+++ b/lib/gauss.c
@@ -37,9 +37,6 @@ unsigned long long gauss_next(struct gauss_state *gs)
 		sum += dev;
 	}
 
-	if (!gs->disable_hash)
-		sum = __hash_u64(sum);
-
 	return sum % gs->nranges;
 }
 
@@ -55,9 +52,4 @@ void gauss_init(struct gauss_state *gs, unsigned long nranges, double dev,
 		if (gs->stddev > nranges / 2)
 			gs->stddev = nranges / 2;
 	}
-}
-
-void gauss_disable_hash(struct gauss_state *gs)
-{
-	gs->disable_hash = true;
 }

--- a/lib/gauss.h
+++ b/lib/gauss.h
@@ -8,12 +8,10 @@ struct gauss_state {
 	struct frand_state r;
 	uint64_t nranges;
 	unsigned int stddev;
-	bool disable_hash;
 };
 
 void gauss_init(struct gauss_state *gs, unsigned long nranges, double dev,
 		unsigned int seed);
 unsigned long long gauss_next(struct gauss_state *gs);
-void gauss_disable_hash(struct gauss_state *gs);
 
 #endif

--- a/lib/zipf.c
+++ b/lib/zipf.c
@@ -64,9 +64,6 @@ uint64_t zipf_next(struct zipf_state *zs)
 
 	val--;
 
-	if (!zs->disable_hash)
-		val = __hash_u64(val);
-
 	return (val + zs->rand_off) % zs->nranges;
 }
 
@@ -84,13 +81,5 @@ uint64_t pareto_next(struct zipf_state *zs)
 
 	n = (zs->nranges - 1) * pow(rand, zs->pareto_pow);
 
-	if (!zs->disable_hash)
-		n = __hash_u64(n);
-
 	return (n + zs->rand_off)  % zs->nranges;
-}
-
-void zipf_disable_hash(struct zipf_state *zs)
-{
-	zs->disable_hash = true;
 }

--- a/lib/zipf.h
+++ b/lib/zipf.h
@@ -13,7 +13,6 @@ struct zipf_state {
 	double pareto_pow;
 	struct frand_state rand;
 	uint64_t rand_off;
-	bool disable_hash;
 };
 
 void zipf_init(struct zipf_state *zs, uint64_t nranges, double theta, unsigned int seed);
@@ -21,6 +20,5 @@ uint64_t zipf_next(struct zipf_state *zs);
 
 void pareto_init(struct zipf_state *zs, uint64_t nranges, double h, unsigned int seed);
 uint64_t pareto_next(struct zipf_state *zs);
-void zipf_disable_hash(struct zipf_state *zs);
 
 #endif


### PR DESCRIPTION
Removes hashing for both, file-named based distributions and LBA based distributions